### PR TITLE
Use a callable instead of an instance for potential interlib dependency

### DIFF
--- a/charm/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -37,7 +37,7 @@ class CatalogueConsumer(Object):
         self,
         charm,
         relation_name: str = DEFAULT_RELATION_NAME,
-        item: CatalogueItem = None,
+        item: Optional[CatalogueItem] = None,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
     ):
         super().__init__(charm, relation_name)

--- a/charm/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -12,8 +12,8 @@ from ops.charm import CharmBase
 from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "fa28b361293b46668bcd1f209ada6983"
-LIBAPI = 0
-LIBPATCH = 2
+LIBAPI = 1
+LIBPATCH = 1
 
 DEFAULT_RELATION_NAME = "catalogue"
 

--- a/charm/pyproject.toml
+++ b/charm/pyproject.toml
@@ -47,6 +47,7 @@ namespace_packages = true
 explicit_package_bases = true
 check_untyped_defs = true
 allow_redefinition = true
+no_implicit_optional = false
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -9,7 +9,7 @@
 import json
 import logging
 
-from charms.catalogue_k8s.v0.catalogue import (
+from charms.catalogue_k8s.v1.catalogue import (
     CatalogueItemsChangedEvent,
     CatalogueProvider,
 )

--- a/charm/tests/unit/test_catalogue_consumer.py
+++ b/charm/tests/unit/test_catalogue_consumer.py
@@ -3,15 +3,12 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import json
 import textwrap
 import unittest
-from unittest.mock import patch
 
 from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
 from ops.charm import CharmBase
-from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
-from ops.model import ActiveStatus
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 from ops.testing import Harness
 
 

--- a/charm/tests/unit/test_catalogue_consumer.py
+++ b/charm/tests/unit/test_catalogue_consumer.py
@@ -1,0 +1,108 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+import json
+import textwrap
+import unittest
+from unittest.mock import patch
+
+from charms.catalogue_k8s.v1.catalogue import CatalogueConsumer, CatalogueItem
+from ops.charm import CharmBase
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+from ops.model import ActiveStatus
+from ops.testing import Harness
+
+
+class CustomEvent(EventBase):
+    """Some custom event that is emitted mid-hook (without charm re-init)."""
+
+
+class DummyEvents(ObjectEvents):
+    """Dummy events."""
+
+    custom_event = EventSource(CustomEvent)
+
+
+class DummyLib(Object):
+    on = DummyEvents()
+
+    def __init__(self, charm):
+        super().__init__(charm, "some_relation_name")
+        self.some_dynamic_value = ""  # will be updated later, e.g. via a core event
+
+    def update_something(self, something: str):
+        self.some_dynamic_value = something
+        self.on.custom_event.emit()
+
+
+class DummyConsumerCharm(CharmBase):
+    metadata_yaml = textwrap.dedent(
+        """
+        name: DummyConsumerCharm
+        requires:
+          catalogue:
+            interface: catalogue
+        """
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+        self.dummy_lib = DummyLib(self)
+
+        # The dynamic value is updated in leader-elected
+        self.framework.observe(self.on.leader_elected, self._on_leader_elected)
+
+        self.catalogue = CatalogueConsumer(
+            charm=self,
+            refresh_event=[
+                self.dummy_lib.on.custom_event,
+            ],
+            item_getter=lambda: CatalogueItem(
+                name=self.dynamic_name(),
+                url=self.dynamic_url(),
+                icon=self.dynamic_icon(),
+            ),
+        )
+
+    def _on_leader_elected(self, _):
+        self.dummy_lib.update_something("foo")
+        # at this point, the self.catalogue item should have "foo"
+
+    def dynamic_name(self):
+        return "DummyCharm-" + self.dummy_lib.some_dynamic_value
+
+    def dynamic_url(self):
+        return "http://some.url/" + self.dummy_lib.some_dynamic_value
+
+    def dynamic_icon(self):
+        return "some-cool-icon-" + self.dummy_lib.some_dynamic_value
+
+
+class TestDeferredEvaluation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = Harness(DummyConsumerCharm, meta=DummyConsumerCharm.metadata_yaml)
+        self.addCleanup(self.harness.cleanup)
+
+        self.rel_id = self.harness.add_relation("catalogue", "catalogue-provider-app")
+
+    def test_item_updated_after_charm_init(self):
+        # WHEN a catalogue instance is only instantiated
+        self.harness.set_leader(False)
+        self.harness.begin_with_initial_hooks()
+
+        # THEN no relation data is present
+        app_data = self.harness.get_relation_data(self.rel_id, self.harness.charm.app.name)
+        self.assertEqual(app_data, {})
+
+        # WHEN a custom refresh event is observed (via a core event, in this case: leader-elected)
+        self.harness.set_leader(True)
+
+        # THEN the catalogue consumer is deferring evaluation and as a result relation data is
+        # up-to-date and includes the dynamic value
+        app_data = self.harness.get_relation_data(self.rel_id, self.harness.charm.app.name)
+        self.assertEqual(
+            app_data,
+            {"name": "DummyCharm-foo", "url": "http://some.url/foo", "icon": "some-cool-icon-foo"},
+        )

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -37,7 +37,7 @@ class TestCharm(unittest.TestCase):
                 "catalogue": {
                     "override": "replace",
                     "summary": "catalogue",
-                    "command": "python3 -m http.server 80",
+                    "command": "nginx",
                     "startup": "enabled",
                 }
             },

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ import json
 import unittest
 from unittest.mock import patch
 
-from charms.catalogue_k8s.v0.catalogue import DEFAULT_RELATION_NAME
+from charms.catalogue_k8s.v1.catalogue import DEFAULT_RELATION_NAME
 from ops.model import ActiveStatus
 from ops.testing import Harness
 


### PR DESCRIPTION
## Problem
I think I figured out the [issue](https://github.com/canonical/catalogue-k8s-operator/issues/3) with catalogue URL for prometheus:
- We observe `self.ingress.on.ready_for_unit`, but it is a custom event, which does not re-init the charm.
- The catalogue attr was already created with `item=CatalogueItem(url=self.external_url, ...)` before the custom `ready_for_unit` event was processed.
- This is an issue only with IPU, because only in IPU obtaining the url is mediated via storedstate (which the lib need to set) - in IPA and route it's reldata directly.

```python
        self.catalogue = CatalogueConsumer(
            charm=self,
            refresh_event=[
                self.on.prometheus_pebble_ready,
                self.on.leader_elected,
                self.ingress.on.ready_for_unit,
                self.ingress.on.revoked_for_unit,
                self.on.config_changed,  # web_external_url; also covers upgrade-charm
            ],
            item=CatalogueItem(
                name="Prometheus",
                icon="chart-line-variant",
                url=self.external_url,
                description=(
                    "Prometheus collects, stores and serves metrics as time series data, "
                    "alongside optional key-value pairs called labels."
                ),
            ),
        )
```

## Solution
Instead of passing an instance of `CatalogueItem`, pass a callable returning a `CatalogueItem`.

This proposed pattern relies on another pattern: libs handle their relation events and emit custom events for the charm to observe.

### Prior art
- https://github.com/canonical/alertmanager-k8s-operator/blob/7d52879f3c5ac2c317da973f795cd3f8ac3a9b8a/src/charm.py#L111
- https://github.com/canonical/observability-libs/blob/cbf882fcfe75a2135dcfa966213521dd9eb2a635/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py#L446