### PR TITLE
fix enabling https after writing certificates

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -113,7 +113,7 @@ class CatalogueCharm(CharmBase):
         if self.server_cert.key:
             self.workload.push(KEY_PATH, self.server_cert.key, make_dirs=True)
 
-    def _configure(self, items, push_certs: bool = False):
+    def _configure(self, items, push_certs: bool = True):
         if not self.workload.can_connect():
             self._update_status(WaitingStatus("Waiting for Pebble ready"))
             return

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -113,7 +113,7 @@ class CatalogueCharm(CharmBase):
         if self.server_cert.key:
             self.workload.push(KEY_PATH, self.server_cert.key, make_dirs=True)
 
-    def _configure(self, items, push_certs: bool = True):
+    def _configure(self, items, push_certs: bool = False):
         if not self.workload.can_connect():
             self._update_status(WaitingStatus("Waiting for Pebble ready"))
             return
@@ -247,7 +247,7 @@ class CatalogueCharm(CharmBase):
 
     @property
     def _tls_enabled(self) -> bool:
-        return bool(self.server_cert.cert)
+        return self.server_cert.enabled and self.workload.exists(CERT_PATH)
 
 
 if __name__ == "__main__":

--- a/charm/tox.ini
+++ b/charm/tox.ini
@@ -82,6 +82,9 @@ commands =
 allowlist_externals =
     /usr/bin/env
 
+[testenv:scenario]
+description = Run scenario tests
+
 [testenv:integration]
 description = Run integration tests
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands = tox -c {[vars]charm_path} -e unit
 
 [testenv:scenario]
 description = Run scenario tests
+commands = tox -c {[vars]charm_path} -e scenario
 
 [testenv:integration]
 description = Run integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,9 @@ commands = tox -c {[vars]charm_path} -e static-lib
 description = Run unit tests
 commands = tox -c {[vars]charm_path} -e unit
 
+[testenv:scenario]
+description = Run scenario tests
+
 [testenv:integration]
 description = Run integration tests
 commands = tox -c {[vars]charm_path} -e integration


### PR DESCRIPTION
## Issue
Fixes #31.

I believe the issue is that Nginx enable HTTPS in the `_configure()` method as soon as the certs are available (by checking the relation data directly). However, at the moment the certificates are written to disk only after a `server-cert-changed` signal. This means that **if the certificate becomes available while some other event is running, the `server-cert-changed` will still be queued and HTTPS will be enabled without the certs being there.**

## Solution

**TL:DR;** `_tls_enabled` should check if the certs have been written to disk already.

There are two possible solutions:
1. try to write the certs on every `_configure()` call, not only on `server-cert-changed`; this means that certs will be written to disk if they are available, without waiting on a specific event; (this solution leaves a small timing window of failure if the certificate is written to relation data **after** checking if it's in relation data but **before** the Nginx configuration is generated)
2. change the check for `_tls_enabled` to include the certificate being written to disk; this guarantees Nginx will enable HTTPS only if the certificate exists; in the scenario depicted in the "Issue" section, the `_configure()` calls won't break the service; at some point `server-cert-changed` will be executed and will take care of running `_configure()`, which this time will enable TLS.

This PR implements number 2.