### PR TITLE
Update ingress on cert change

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -48,13 +48,11 @@ class CatalogueCharm(CharmBase):
         self._info = CatalogueProvider(charm=self)
         self._ingress = IngressPerAppRequirer(charm=self, port=80, strip_prefix=True)
 
-        url = self.hostname
-        extra_sans_dns = [cast(str, urlparse(url).hostname)] if url else None
         self.server_cert = CertHandler(
             self,
             key="catalogue-server-cert",
             peer_relation_name="replicas",
-            extra_sans_dns=extra_sans_dns,
+            extra_sans_dns=[socket.getfqdn()],
         )
 
         self.framework.observe(
@@ -249,11 +247,6 @@ class CatalogueCharm(CharmBase):
             "description": self.model.config.get("description", ""),
             "links": json.loads(self.model.config["links"]),
         }
-
-    @property
-    def hostname(self) -> str:
-        """Unit's hostname."""
-        return socket.getfqdn()
 
     def _is_tls_ready(self) -> bool:
         """Returns True if the workload is ready to operate in TLS mode."""

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -81,7 +81,10 @@ class CatalogueCharm(CharmBase):
         logger.info("This app no longer has ingress")
 
     def _on_catalogue_pebble_ready(self, _):
-        self._configure(self.items)
+        # We set push_certs to True here to cover the upgrade sequence. When upgrade-charm fires,
+        # the container may not yet be ready, and the certs are written to non-persistent storage
+        # (which is a good thing).
+        self._configure(self.items, push_certs=True)
 
     def _update_status(self, status):
         if self.unit.is_leader():
@@ -89,6 +92,8 @@ class CatalogueCharm(CharmBase):
         self.unit.status = status
 
     def _on_upgrade(self, _):
+        # Ideally we would want to push certs on upgrade, but at this point we can't know for sure
+        # if pebble-ready (can_connect guard).
         self._configure(self.items)
 
     def _on_config_changed(self, _):

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -9,7 +9,6 @@
 import json
 import logging
 import socket
-from typing import cast
 from urllib.parse import urlparse
 
 from charms.catalogue_k8s.v0.catalogue import (

--- a/charm/tox.ini
+++ b/charm/tox.ini
@@ -73,6 +73,7 @@ deps =
     -r{toxinidir}/requirements.txt
     deepdiff
     httpcore==0.14.7
+    pydantic<2  # from traefik_k8s.v2.ingress
 commands =
     python -m doctest {[vars]src_path}/charm.py
     coverage run \


### PR DESCRIPTION
Fixes #43.

To test, deploy the following bundle and attempt to curl catalogue via its ingress url.
```yaml
bundle: kubernetes
applications:
  ca:
    charm: self-signed-certificates
    channel: edge
    revision: 37
    scale: 1
    constraints: arch=amd64
  cat:
    charm: local:catalogue-k8s-3
    series: focal
    scale: 1
    constraints: arch=amd64
  external-ca:
    charm: self-signed-certificates
    channel: edge
    revision: 37
    scale: 1
    constraints: arch=amd64
  trfk:
    charm: traefik-k8s
    channel: edge
    revision: 157
    series: focal
    resources:
      traefik-image: 148
    scale: 1
    options:
      external_hostname: cluster.local
      routing_mode: path
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
relations:
- - external-ca:certificates
  - trfk:certificates
- - ca:send-ca-cert
  - trfk:receive-ca-cert
- - cat:ingress
  - trfk:ingress
- - cat:certificates
  - ca:certificates
```