### PR TITLE
Do not raise on error for alertmanager

### DIFF
--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -77,7 +77,10 @@ async def test_app_integration(ops_test: OpsTest):
 
     await ops_test.model.integrate(f"{APP_NAME}", alert_app_name)
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, alert_app_name], status="active", raise_on_blocked=True, timeout=1000
+        apps=[APP_NAME, alert_app_name], status="active", raise_on_error=False, timeout=1000
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, alert_app_name], status="active", raise_on_blocked=True, timeout=60
     )
     # retrieve the content of /web/config.json which holds application data in the catalogue
     new_config = await run_juju_ssh_command(


### PR DESCRIPTION
## Issue
Integration test [failing](https://github.com/canonical/catalogue-k8s-operator/actions/runs/8101218450/job/22140964598#step:7:1641) because alertmanager goes into error status on `start` hook, due to pebble issues:
```
unit.alertmanager-k8s/0.juju-log Pebble API is not ready; ConnectionError: [Errno 2] No such file or directory
```


## Solution
Set raise_on_error to False, followed by the original wait_for_idle.