### PR TITLE
add open port support

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -17,14 +17,12 @@ from charms.catalogue_k8s.v1.catalogue import (
     CatalogueProvider,
 )
 from charms.observability_libs.v0.cert_handler import CertHandler
-from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from charms.tempo_k8s.v1.charm_tracing import trace_charm
 from charms.tempo_k8s.v2.tracing import TracingEndpointRequirer
 from charms.traefik_k8s.v2.ingress import (
     IngressPerAppReadyEvent,
     IngressPerAppRequirer,
 )
-from lightkube.models.core_v1 import ServicePort
 from nginx_config import CA_CERT_PATH, CERT_PATH, KEY_PATH, NGINX_CONFIG_PATH, NginxConfigBuilder
 from ops.charm import CharmBase
 from ops.main import main
@@ -44,7 +42,6 @@ CONFIG_PATH = ROOT_PATH + "/config.json"
         CatalogueProvider,
         CertHandler,
         IngressPerAppRequirer,
-        KubernetesServicePatch,
     ),
 )
 class CatalogueCharm(CharmBase):
@@ -54,8 +51,7 @@ class CatalogueCharm(CharmBase):
         super().__init__(*args)
         self.name = "catalogue"  # container, layer, service
 
-        port = ServicePort(80, name=f"{self.app.name}")
-        self.service_patcher = KubernetesServicePatch(self, [port])
+        self.unit.open_port(protocol="tcp", port=80)
 
         self._tracing = TracingEndpointRequirer(self, protocols=["otlp_http"])
 

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -17,7 +17,6 @@ CONTAINER_NAME = "catalogue"
 
 
 class TestCharm(unittest.TestCase):
-    @patch("charm.KubernetesServicePatch", lambda x, y: None)
     def setUp(self):
         self.harness = Harness(CatalogueCharm)
         self.addCleanup(self.harness.cleanup)


### PR DESCRIPTION
## Issue

Use `ops.Unit.open_port` for the port to show up in Juju status.

Due to a Juju bug, it might not show up there yet; use `juju exec <unit> -- opened-ports` to verify.

## Testing Instructions

```
charmcraft pack
juju deploy ./catalogue-k8s_ubuntu-20.04-amd64.charm catalogue
# Wait for the charm
juju exec --unit catalogue/0 -- opened-ports
```