### PR TITLE
fix: use set_ports instead of open_port

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -51,7 +51,7 @@ class CatalogueCharm(CharmBase):
         super().__init__(*args)
         self.name = "catalogue"  # container, layer, service
 
-        self.unit.open_port(protocol="tcp", port=80)
+        self.unit.set_ports(80)
 
         self._tracing = TracingEndpointRequirer(self, protocols=["otlp_http"])
 


### PR DESCRIPTION
## Issue

`open_port` doesn't close ports; if the port changes on upgrades, the previous one isn't closed.

## Solution

Use `set_ports` instead, as documented [here](https://github.com/canonical/operator/blob/ab239e1156bd206f9825b5be96fbf83121489fee/ops/model.py#L699).