### PR TITLE
switch update-libs ci to the automerge branch

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-lib:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@main
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@feature/automerge
     secrets: inherit
     with:
       charm-path: "charm"


### PR DESCRIPTION
This switch is necessary to properly test and validate some changes to the **charm-update-libs.yaml** workflow, with the purpose to:
* have signed commits from the `update-libs` workflow
* auto-merge `update-libs` PRs on green CI
* create a PR for major charm library updates as well (without auto-merging)