### PR TITLE
test: correct ruff invocation

### DIFF
--- a/charm/tox.ini
+++ b/charm/tox.ini
@@ -33,7 +33,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -46,7 +46,7 @@ commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip nginx_config.py --skip tox.ini
     codespell src/nginx_config.py -L anull
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
## Summary

Fixes

```
error: `ruff  <path>` has been removed. Use `ruff check <path>` instead.
```


## Testing Instructions

Run `tox -e lint`
