### PR TITLE
fix: shadow rendering

### DIFF
--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -61,7 +61,8 @@
         <ul class="p-matrix" id="apps">
           {{! --- Apps --- }}
           {{#each apps}}
-             <li class="p-matrix__item">
+              <li class="p-matrix__item">
+			  {{#if name}}
               <div class="p-matrix__img">
                 <span class="iconify icon md-48" data-icon="mdi-{{icon}}"></span>
               </div>
@@ -71,7 +72,8 @@
                 <p class="p-matrix__desc">{{description}}</p>
                 {{/if}}  
               </div>
-            </li>
+			  {{/if}}
+              </li>
             {{/each}}
         </ul>
         {{else}}

--- a/workload/ui/ui.css
+++ b/workload/ui/ui.css
@@ -4,10 +4,14 @@
     border: 1px solid #d9d9d9;
     padding: 8px;
     border-radius: 100%;
-  }
+}
 
-  .link-list {
+.p-matrix__item {
+    border: 0;
+}
+
+.link-list {
     list-style-type: none;
     margin: 0;
     padding: 0;
-  }
+}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Catalogue is currently rendering shadow items to fill out rows. While we need this to get proper spacing, we should not render any subelements as a result of this.

## Solution
<!-- A summary of the solution addressing the above issue -->

* Hide icon, name, link, and description behind a condition.
* Don't render borders between items in the matrix.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
ROCK is currently not being built by CI. When merging, please make sure a rebuild of the rock is performed and pushed upstream.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
