### PR TITLE
fix: redirect http to https when tls is enabled

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -68,6 +68,7 @@ class CatalogueCharm(CharmBase):
             charm=self,
             port=self._internal_port,
             strip_prefix=True,
+            redirect_https=True,
             scheme=lambda: urlparse(self._internal_url).scheme,
         )
         self.framework.observe(


### PR DESCRIPTION
resolves #127 

## Issue
<!-- What issue is this PR trying to solve? -->
Catalogue is not enforcing TLS termination when available.


## Solution
<!-- A summary of the solution addressing the above issue -->
Redirect all HTTP calls to HTTPS when TLS is enabled

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
