### PR TITLE
fix: remove unnecessary status update guard

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -187,8 +187,7 @@ class CatalogueCharm(CharmBase):
                 logger.error(msg)
                 return
 
-        if self.unit.is_leader():
-            self._update_status(ActiveStatus())
+        self._update_status(ActiveStatus())
 
     def _update_pebble_layer(self) -> bool:
         current_layer = self.workload.get_plan()


### PR DESCRIPTION
resolves #25 

## Issue
<!-- What issue is this PR trying to solve? -->
Additional units get stuck in `unknown` due to an unnecessary leader guard.

## Solution
<!-- A summary of the solution addressing the above issue -->
Remove the leader guard as we already guard against illegal application status manipulation in the `_update_status` function.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
