### PR TITLE
replace mattermost link with community matrix

### DIFF
--- a/charm/config.yaml
+++ b/charm/config.yaml
@@ -37,8 +37,8 @@ options:
           "category": "Social",
           "items": [
             {
-              "name": "Mattermost",
-              "url": "https://chat.charmhub.io",
+              "name": "Ubuntu Matrix Community",
+              "url": "https://matrix.to/#/#community:ubuntu.com",
               "target": "_blank"
             },
             {


### PR DESCRIPTION
resolves #62 

## Issue
<!-- What issue is this PR trying to solve? -->
Links to our old community mattermost, which is no longer available.

## Solution
<!-- A summary of the solution addressing the above issue -->
Replaces the link with a matrix invite link.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
