### PR TITLE
[tf] Update the outputs.tf with endpoints nomenclature

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,16 +2,11 @@ output "app_name" {
   value = juju_application.catalogue.name
 }
 
-output "requires" {
+output "endpoints" {
   value = {
+    catalogue = "catalogue",
     certificates = "certificates",
     ingress      = "ingress",
     tracing      = "tracing",
-  }
-}
-
-output "provides" {
-  value = {
-    catalogue = "catalogue",
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,7 +8,6 @@ output "endpoints" {
     certificates = "certificates",
     ingress      = "ingress",
     tracing      = "tracing",
-    
     # Provides
     catalogue = "catalogue",
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,7 +4,7 @@ output "app_name" {
 
 output "endpoints" {
   value = {
-    catalogue = "catalogue",
+    catalogue    = "catalogue",
     certificates = "certificates",
     ingress      = "ingress",
     tracing      = "tracing",

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,9 +4,12 @@ output "app_name" {
 
 output "endpoints" {
   value = {
-    catalogue    = "catalogue",
+    # Requires
     certificates = "certificates",
     ingress      = "ingress",
     tracing      = "tracing",
+    
+    # Provides
+    catalogue = "catalogue",
   }
 }


### PR DESCRIPTION
To remove implementation detail of the TF module when another module inherits it, it makes sense to replace the `requires` and `provides` output variables with `endpoints`.

Coordinating PR
- https://github.com/canonical/observability/pull/226