### PR TITLE
[Proof of Concept] New catalogue lib version

### DIFF
--- a/charm/lib/charms/catalogue_k8s/v2/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v2/catalogue.py
@@ -5,9 +5,10 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List
 
-from ops.model import Application, Relation
+if TYPE_CHECKING:
+    from ops.model import Application, Relation
 
 LIBID = "fa28b361293b46668bcd1f209ada6983"
 LIBAPI = 2
@@ -33,7 +34,7 @@ class CatalogueConsumer:
     """`CatalogueConsumer` is used to send over a `CatalogueItem`."""
 
     @staticmethod
-    def update_item(item: CatalogueItem, relations: List[Relation] , app: Application, is_leader: bool = False):
+    def update_item(item: CatalogueItem, relations: List["Relation"] , app: "Application", is_leader: bool = False):
         """Update item on Catalogue."""
         if not is_leader:
             return
@@ -48,7 +49,7 @@ class CatalogueProvider:
     """`CatalogueProvider` is the side of the relation that serves the actual service catalogue."""
 
     @staticmethod
-    def items(relations: List[Relation]) -> List[Dict]:
+    def items(relations: List["Relation"]) -> List[Dict]:
         """List of apps sent over relation data."""
         return [
             {

--- a/charm/lib/charms/catalogue_k8s/v2/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v2/catalogue.py
@@ -4,7 +4,7 @@
 """Charm for providing services catalogues to bundles or sets of charms."""
 
 import logging
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Dict, List
 
 if TYPE_CHECKING:
@@ -40,10 +40,7 @@ class CatalogueConsumer:
             return
 
         for relation in relations:
-            relation.data[app]["name"] = item.name
-            relation.data[app]["description"] = item.description
-            relation.data[app]["url"] = item.url
-            relation.data[app]["icon"] = item.icon
+            relation.data[app].update(asdict(item))
 
 class CatalogueProvider:
     """`CatalogueProvider` is the side of the relation that serves the actual service catalogue."""
@@ -51,13 +48,4 @@ class CatalogueProvider:
     @staticmethod
     def items(relations: List["Relation"]) -> List[Dict]:
         """List of apps sent over relation data."""
-        return [
-            {
-                "name": relation.data[relation.app].get("name", ""),
-                "url": relation.data[relation.app].get("url", ""),
-                "icon": relation.data[relation.app].get("icon", ""),
-                "description": relation.data[relation.app].get("description", ""),
-            }
-            for relation in relations
-            if relation.app and relation.units
-        ]
+        return [dict(relation.data[relation.app]) for relation in relations if relation.app and relation.units]

--- a/charm/lib/charms/catalogue_k8s/v2/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v2/catalogue.py
@@ -30,8 +30,8 @@ class CatalogueItem:
     icon: str
     description: str = ""
 
-class CatalogueConsumer:
-    """`CatalogueConsumer` is used to send over a `CatalogueItem`."""
+class CatalogueRequirer:
+    """`CatalogueRequirer` is used to send over a `CatalogueItem`."""
 
     @staticmethod
     def update_item(item: CatalogueItem, relations: List["Relation"] , app: "Application", is_leader: bool = False):

--- a/charm/lib/charms/catalogue_k8s/v2/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v2/catalogue.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Charm for providing services catalogues to bundles or sets of charms."""
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List
+
+from ops.model import Application, Relation
+
+LIBID = "fa28b361293b46668bcd1f209ada6983"
+LIBAPI = 2
+LIBPATCH = 1
+
+DEFAULT_RELATION_NAME = "catalogue"
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class CatalogueItem:
+    """`CatalogueItem` represents an application entry sent to a catalogue.
+
+    The icon is an iconify mdi string; see https://icon-sets.iconify.design/mdi.
+    """
+
+    name: str
+    url: str
+    icon: str
+    description: str = ""
+
+class CatalogueConsumer:
+    """`CatalogueConsumer` is used to send over a `CatalogueItem`."""
+
+    @staticmethod
+    def update_item(item: CatalogueItem, relations: List[Relation] , app: Application, is_leader: bool = False):
+        """Update item on Catalogue."""
+        if not is_leader:
+            return
+
+        for relation in relations:
+            relation.data[app]["name"] = item.name
+            relation.data[app]["description"] = item.description
+            relation.data[app]["url"] = item.url
+            relation.data[app]["icon"] = item.icon
+
+class CatalogueProvider():
+    """`CatalogueProvider` is the side of the relation that serves the actual service catalogue."""
+
+    @staticmethod
+    def items(relations: List[Relation]) -> List[Dict]:
+        """List of apps sent over relation data."""
+        return [
+            {
+                "name": relation.data[relation.app].get("name", ""),
+                "url": relation.data[relation.app].get("url", ""),
+                "icon": relation.data[relation.app].get("icon", ""),
+                "description": relation.data[relation.app].get("description", ""),
+            }
+            for relation in relations
+            if relation.app and relation.units
+        ]

--- a/charm/lib/charms/catalogue_k8s/v2/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v2/catalogue.py
@@ -44,7 +44,7 @@ class CatalogueConsumer:
             relation.data[app]["url"] = item.url
             relation.data[app]["icon"] = item.icon
 
-class CatalogueProvider():
+class CatalogueProvider:
     """`CatalogueProvider` is the side of the relation that serves the actual service catalogue."""
 
     @staticmethod

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -96,7 +96,7 @@ class CatalogueCharm(CharmBase):
         self.framework.observe(self.on.get_url_action, self._get_url)
 
 
-    def _update_own_item_in_anoother_catalogue(self) -> None:
+    def _update_own_item_in_another_catalogue(self) -> None:
         relations = self.model.relations["catalogue-item"]
         app = self.model.app
         is_leader = self.unit.is_leader()

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -193,7 +193,7 @@ class CatalogueCharm(CharmBase):
                 logger.error(str(e))
                 return
 
-        self._update_own_item_in_anoother_catalogue()
+        self._update_own_item_in_another_catalogue()
         nginx_config_changed = self._update_web_server_config()
         catalogue_config_changed = self._update_catalogue_config(self.items)
         pebble_layer_changed = self._update_pebble_layer()

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import unittest
 from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
-from charms.catalogue_k8s.v1.catalogue import DEFAULT_RELATION_NAME
+from charms.catalogue_k8s.v2.catalogue import DEFAULT_RELATION_NAME
 from ops.charm import ActionEvent
 from ops.model import ActiveStatus
 from ops.testing import Harness
@@ -126,7 +126,7 @@ class TestCharm(unittest.TestCase):
         mock_logger.info.assert_called_with(
             "This app's ingress URL: %s", "https://testingress.com"
         )
-        mock_configure.assert_called_with({"name": "test_value"}, push_certs=True)
+        mock_configure.assert_called_with(push_certs=True)
 
         mock_logger.reset_mock()
         mock_configure.reset_mock()
@@ -136,7 +136,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_ingress_revoked(None)
 
         mock_logger.info.assert_called_with("This app no longer has ingress")
-        mock_configure.assert_called_with([], push_certs=True)
+        mock_configure.assert_called_with(push_certs=True)
 
     def test_get_url_action_no_ingress(self):
         action_event = Mock(spec=ActionEvent)

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -63,6 +63,7 @@ class TestCharm(unittest.TestCase):
                 "name": "remote-charm",
                 "url": "https://localhost",
                 "icon": "some-cool-icon",
+                "description": "Description",
             },
         )
 
@@ -73,7 +74,7 @@ class TestCharm(unittest.TestCase):
                     "name": "remote-charm",
                     "url": "https://localhost",
                     "icon": "some-cool-icon",
-                    "description": "",
+                    "description": "Description",
                 }
             ],
             json.loads(data.read())["apps"],


### PR DESCRIPTION
## Proof of Concept
<!-- What issue is this PR trying to solve? -->

The idea of this PoC is to add a new `v2` version of the `Catalogue` library that does not depend on `ops`.

The main differences between `v1` and `v2` are:

- `v2` neither observes nor emits any event.
- `CatalogueItem` is now a `dataclass`
- `CatalogueRequirer` and `CatalogueProvider` does not inherit from `ops.Object`
- `unit_address` method removed from `CatalogueConsumer` object, since the `url` is a `CatalogueItem` property.
- `CatalogueRequirer` has only one static method: `update_item` which updates `CatalogueItem` in relation data.
- `CatalogueProvider` has only one static method: `items` that retrieve items for a specific relation.

Thus, the `v2` library has only 51 lines, while `v1` has 165.

Tandem PR which show how to use the Consumer side of the library: https://github.com/Abuelodelanada/snips-k8s-operator/pull/3


