### PR TITLE
chore: conform with public listing requirements

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -8,6 +8,7 @@ description: |
   interfaces of the charms related to it.
 
 links:
+  documentation: https://discourse.charmhub.io/t/catalogue-k8s-index/17904
   website: https://charmhub.io/catalogue-k8s
   source: https://github.com/canonical/catalogue-k8s-operator
   issues: https://github.com/canonical/catalogue-k8s-operator/issues

--- a/charm/tests/integration/test_charm.py
+++ b/charm/tests/integration/test_charm.py
@@ -3,7 +3,6 @@
 # See LICENSE file for licensing details.
 
 
-import asyncio
 import json
 import logging
 from pathlib import Path
@@ -48,13 +47,11 @@ async def test_build_and_deploy(ops_test: OpsTest, catalogue_charm):
 
 async def test_tls(ops_test: OpsTest):
     assert ops_test.model
-    await asyncio.gather(
-        ops_test.model.deploy(
-            "self-signed-certificates",
-            application_name=ssc_app_name,
-            channel="latest/edge",
-            trust=True,
-        ),
+    await ops_test.model.deploy(
+        "self-signed-certificates",
+        application_name=ssc_app_name,
+        channel="1/edge",
+        trust=True,
     )
     await ops_test.model.add_relation(APP_NAME, ssc_app_name)
     await ops_test.model.wait_for_idle(apps=app_names, status="active")
@@ -68,13 +65,11 @@ async def test_tls(ops_test: OpsTest):
 async def test_app_integration(ops_test: OpsTest):
     assert ops_test.model
     assert ops_test.model_full_name
-    await asyncio.gather(
-        ops_test.model.deploy(
-            prometheus_app_name,
-            application_name=prometheus_app_name,
-            channel="1/stable",
-            trust=True,
-        ),
+    await ops_test.model.deploy(
+        prometheus_app_name,
+        application_name=prometheus_app_name,
+        channel="1/stable",
+        trust=True,
     )
 
     await ops_test.model.integrate(f"{APP_NAME}", prometheus_app_name)

--- a/charm/tests/integration/test_ingress.py
+++ b/charm/tests/integration/test_ingress.py
@@ -27,7 +27,7 @@ async def test_build_and_deploy(ops_test: OpsTest, catalogue_charm):
     resources = {"catalogue-image": METADATA["resources"]["catalogue-image"]["upstream-source"]}
     await ops_test.model.deploy(catalogue_charm, resources=resources, application_name="catalogue")
 
-    # issuing dummy update_status just to trigger an event
+    # issuing fake update_status just to trigger an event
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
             apps=["catalogue"],

--- a/charm/tests/integration/test_ingress.py
+++ b/charm/tests/integration/test_ingress.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import logging
+from pathlib import Path
+
+import pytest
+import requests
+import sh
+import yaml
+from helpers import get_unit_address
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, catalogue_charm):
+    assert ops_test.model
+    # Given a fresh build of the charm
+    # When deploying it
+    # Then it should eventually go idle/active
+    resources = {"catalogue-image": METADATA["resources"]["catalogue-image"]["upstream-source"]}
+    await ops_test.model.deploy(catalogue_charm, resources=resources, application_name="catalogue")
+
+    # issuing dummy update_status just to trigger an event
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=["catalogue"],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
+
+    assert ops_test.model.applications["catalogue"]
+    assert ops_test.model.applications["catalogue"].units[0].workload_status == "active"
+
+
+async def test_ingress(ops_test: OpsTest):
+    assert ops_test.model
+    sh.juju.deploy(  # type: ignore
+        "traefik-k8s", "traefik", channel="latest/edge", trust=True, model=ops_test.model.name
+    )
+    sh.juju.relate("catalogue:ingress", "traefik", model=ops_test.model.name)  # type: ignore
+    await ops_test.model.wait_for_idle(apps=["catalogue", "traefik"], status="active")
+
+    address = await get_unit_address(ops_test, "traefik", 0)
+    url = f"https://{address}/cos-catalogue"
+    response = requests.get(url, verify=False)
+    assert response.status_code == 200

--- a/charm/tests/integration/test_ingress.py
+++ b/charm/tests/integration/test_ingress.py
@@ -49,6 +49,6 @@ async def test_ingress(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(apps=["catalogue", "traefik"], status="active")
 
     address = await get_unit_address(ops_test, "traefik", 0)
-    url = f"https://{address}/cos-catalogue"
+    url = f"https://{address}/{ops_test.model.name}-catalogue"
     response = requests.get(url, verify=False)
     assert response.status_code == 200


### PR DESCRIPTION
## Issue
We're asked a few things for the publis listing of this charm:

1. Some minimal steps (or a demo) to verify the “intended functionality”. [@james-garner](https://discourse.charmhub.io/u/james-garner)’s suggestion is that a small quick start tutorial would be a nice way of doing this, but the requirement is just that the reviewer can see that the charm does what it says it does. If there isn’t some sort of tutorial, let’s at least have the usage information from the README on the Charmhub landing page.
2. An integration test that verifies that the charm works when a relation providing the ingress interface is provided.
3. Charming best practice is to use a full path when running subprocesses. Can we do that for [update-ca-certificates](https://github.com/canonical/catalogue-k8s-operator/blob/82639f250c49470379cc5b4eb981a65d9ce6c0e7/charm/src/charm.py#L179)? If not, can you explain why not?



## Solution
(1) is solved by a tutorial I wrote [here](https://discourse.charmhub.io/t/catalogue-k8s-getting-started/18088) and adding the docs page to the charm in `charmcraft.yaml`.

(2) is solved by adding the `test_ingress.py` test.

(3) is trickier; I tried to change the charm to run `/usr/sbin/update-ca-certificates`, but the charm somehow fails when I do that.


## Context
#47 

