### PR TITLE
feat: add library description for listing

### DIFF
--- a/charm/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -1,7 +1,57 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charm for providing services catalogues to bundles or sets of charms."""
+"""Charm for providing services catalogues to bundles or sets of charms.
+
+This charm library contains two classes (CatalogueProvider and CatalogueConsumer) that handle
+both sides of the `catalogue` relation interface.
+
+### CatalogueConsumer
+
+The Consumer allows sending catalogue items to a Catalogue charm.
+
+Adding it to your charm is very simple:
+
+    ```
+    from charms.catalogue_k8s.v1.catalogue import (
+        CatalogueConsumer,
+        CatalogueItem,
+    )
+
+    ...
+        self.catalogue = CatalogueConsumer(
+            charm=self,
+            relation_name="catalogue",  # optional
+            item=CatalogueItem(
+                name="myapp",
+                url=myapp_url,
+                icon="rainbow",
+                description="This is a rainbow app!"
+            )
+        )
+    ```
+
+    The relevant events listeners are already registered by the CatalogueConsumer object.
+
+### CatalogueProvider
+
+The Provider helps you receive catalogue items from other charms to display them however you like.
+
+To implement this in your charm:
+
+    ```
+    from charms.catalogue_k8s.v1.catalogue import CatalogueProvider
+
+    ...
+        self.catalogue = CatalogueProvider(
+            charm=self,
+            relation_name="catalogue",  # optional
+        )
+    ```
+
+
+    The relevant events listeners are already registered by the CatalogueProvider object.
+"""
 
 import ipaddress
 import logging
@@ -13,7 +63,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "fa28b361293b46668bcd1f209ada6983"
 LIBAPI = 1
-LIBPATCH = 1
+LIBPATCH = 2
 
 DEFAULT_RELATION_NAME = "catalogue"
 


### PR DESCRIPTION
## Issue
Comply with the listing process. 

> the catalogue interface library should have some extra documentation at the top of the module docstring. We’re still working out what the exact requirements will be in future reviews, but for now, please include the following:
> - clearly state the name of the Juju interface(s), and whether the library is for the provider side, the requirer side, or both
> - provide at least some guidance on how to start using the library to implement their end of the interface
>   - if the charm provides the interface(s), the guidance should at least cover how to start implementing the requirer side
>   - if the charm requires the interface(s), the guidance should at least cover how to start implementing the provider side
