### PR TITLE
feat: add API information to item card

### DIFF
--- a/charm/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -63,7 +63,7 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 LIBID = "fa28b361293b46668bcd1f209ada6983"
 LIBAPI = 1
-LIBPATCH = 2
+LIBPATCH = 3
 
 DEFAULT_RELATION_NAME = "catalogue"
 

--- a/charm/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -54,10 +54,9 @@ To implement this in your charm:
 """
 
 import ipaddress
-import logging
-import socket
-from typing import Optional, Dict
 import json
+import logging
+from typing import Dict, Optional
 
 from ops.charm import CharmBase
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
@@ -211,7 +210,7 @@ class CatalogueProvider(Object):
                 "url": relation.data[relation.app].get("url", ""),
                 "icon": relation.data[relation.app].get("icon", ""),
                 "description": relation.data[relation.app].get("description", ""),
-                "api_docs": relation.data[relation.app].get("api_docs", ""), 
+                "api_docs": relation.data[relation.app].get("api_docs", ""),
                 "api_endpoints": json.loads(relation.data[relation.app].get("api_endpoints", "{}")),
             }
             for relation in self._charm.model.relations[self._relation_name]

--- a/charm/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -73,7 +73,14 @@ logger = logging.getLogger(__name__)
 class CatalogueItem:
     """`CatalogueItem` represents an application entry sent to a catalogue.
 
-    The icon is an iconify mdi string; see https://icon-sets.iconify.design/mdi.
+    icon (str): An Iconify Material Design Icon (MDI) string. 
+        (See: https://icon-sets.iconify.design/mdi for more details).
+    api_docs (str): A URL to the docs relevant to this item (upstream or otherwise).
+    api_endpoints (dict): A dictionary containing API information, where:
+        - The key is a description or name of the endpoint (e.g., "Alerts").
+        - The value is the actual address of the endpoint (e.g., "'http://1.2.3.4:1234/api/v1/targets/metadata'").
+        - Example for setting the api_endpoints attr:
+            api_endpoints={"Alerts": f"{self.external_url}/api/v1/alerts"}
     """
 
     def __init__(self, name: str, url: str, icon: str, description: str = "", api_docs: str = "", api_endpoints: Optional[Dict[str,str]] = None):
@@ -81,8 +88,6 @@ class CatalogueItem:
         self.url = url
         self.icon = icon
         self.description = description
-        # The api is a dict: key: description/name of the endpoint, value is actual address of endpoint
-        # {"docs": "https://prometheus.io/docs/prometheus/latest/querying/api/", "endpoints":{'metadata':'/api/v1/targets/metadata'}}
         self.api_docs = api_docs
         self.api_endpoints = api_endpoints
 

--- a/charm/lib/charms/catalogue_k8s/v1/catalogue.py
+++ b/charm/lib/charms/catalogue_k8s/v1/catalogue.py
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 class CatalogueItem:
     """`CatalogueItem` represents an application entry sent to a catalogue.
 
-    icon (str): An Iconify Material Design Icon (MDI) string. 
+    icon (str): An Iconify Material Design Icon (MDI) string.
         (See: https://icon-sets.iconify.design/mdi for more details).
     api_docs (str): A URL to the docs relevant to this item (upstream or otherwise).
     api_endpoints (dict): A dictionary containing API information, where:

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -74,6 +74,8 @@ class TestCharm(unittest.TestCase):
                     "url": "https://localhost",
                     "icon": "some-cool-icon",
                     "description": "",
+                    "api_docs": "",
+                    "api_endpoints": {}
                 }
             ],
             json.loads(data.read())["apps"],

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -86,7 +86,7 @@ class TestCharm(unittest.TestCase):
         # When a relation is established
         # AND the remote charm exposes an application entry
         # AND the remote charm writes values for api_docs and api_endpoints to the databag
-        # And the catalogue should write the entry to its config
+        # THEN Catalogue should write the entry to its config
         # AND the correct entries should show up for api_docs and api_endpoints in the config.json file
         apidocs = "some_url_to_upstream_docs"
         apiendpoint = {"endpoint_1":"some_endpoint_1", "endpoint_2":"some_endpoint_2"}

--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -81,6 +81,44 @@ class TestCharm(unittest.TestCase):
             json.loads(data.read())["apps"],
         )
 
+    def test_api_type(self):
+        # Given the catalogue and a remote charm
+        # When a relation is established
+        # AND the remote charm exposes an application entry
+        # AND the remote charm writes values for api_docs and api_endpoints to the databag
+        # And the catalogue should write the entry to its config
+        # AND the correct entries should show up for api_docs and api_endpoints in the config.json file
+        apidocs = "some_url_to_upstream_docs"
+        apiendpoint = {"endpoint_1":"some_endpoint_1", "endpoint_2":"some_endpoint_2"}
+        rel_id = self.harness.add_relation(DEFAULT_RELATION_NAME, "rc")
+        self.harness.add_relation_unit(rel_id, "rc/0")
+        self.harness.update_relation_data(
+            rel_id,
+            "rc",
+            {
+                "name": "remote-charm",
+                "url": "https://localhost",
+                "icon": "some-cool-icon",
+                "api_docs":apidocs,
+                "api_endpoints":json.dumps(apiendpoint),
+            },
+        )
+
+        data = self._container.pull("/web/config.json")
+        self.assertEqual(
+            [
+                {
+                    "name": "remote-charm",
+                    "url": "https://localhost",
+                    "icon": "some-cool-icon",
+                    "description": "",
+                    "api_docs": apidocs,
+                    "api_endpoints": apiendpoint
+                }
+            ],
+            json.loads(data.read())["apps"],
+        )
+
     @patch.multiple(
         "charm.CatalogueCharm",
         _push_certs=lambda *_: None,

--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -74,9 +74,15 @@
                    {{/if}}
                    {{#if api_docs}}
                             <h2 class="p-matrix__title"><a class="p-matrix__link" href="{{api_docs}}">API</a></h2>
-                    {{else}}
-                           <h2 class="p-matrix__title">API</h2>
                    {{/if}}
+                   {{#if api_endpoints}}
+                   {{#if api_endpoints}}
+                      <ul>
+                          {{#each api_endpoints}}
+                              <li>{{@key}}: {{this}}</li>
+                          {{/each}}
+                      </ul>
+                  {{/if}}
                    {{#if description}}
                    <p class="p-matrix__desc">{{description}}</p>
                    {{/if}}

--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -81,7 +81,6 @@
                    <p class="p-matrix__desc">{{description}}</p>
                    {{/if}}
                  </div>
-
     		  {{/if}}
                  </li>
                {{/each}}

--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -8,8 +8,6 @@
       name="viewport"
     />
     <script>
-      // If there is no trailing slash at the end of the path in the url,
-      // add one. This ensures assets like ui.css are loaded properly
       if (location.pathname.substr(-1) != "/") {
         location.pathname = location.pathname + "/";
         console.log("added slash");
@@ -22,124 +20,154 @@
   </head>
   <script type="text/handlebars-template" id="root-template">
     <header id="navigation" class="p-navigation is-dark">
-       <div class="p-navigation__row">
-         <div class="p-navigation__banner">
-           <div class="p-navigation__tagged-logo">
-             <a class="p-navigation__link" href="#">
-               <div class="p-navigation__logo-tag">
-                 <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
-               </div>
-               <span class="p-navigation__logo-title" id="nav">
-                   {{title}}
-               </span>
-             </a>
-           </div>
-         </div>
-       </div>
-     </header>
-     <div class="p-strip--suru">
-       <div class="row">
-         <div class="col-12">
-           {{#if tagline}}
-             <h1>{{tagline}}</h1>
-           {{/if}}
-           {{#if description}}
-             <p>{{description}}</p>
-           {{/if}}
-         </div>
-       </div>
-     </div>
-     <div class="p-strip">
-       <div class="row">
-         <div class="col12">
-           <h3>Applications</h3>
-         </div>
-       </div>
-       <div class="row">
-         <div class="col-12">
-           {{#if apps}}
-           <ul class="p-matrix" id="apps">
-             {{! --- Apps --- }}
-             {{#each apps}}
-                 <li class="p-matrix__item">
-    		  {{#if name}}
-                 <div class="p-matrix__img">
-                   <span class="iconify icon md-48" data-icon="mdi-{{icon}}"></span>
-                 </div>
-                 <div class="p-matrix__content">
-                   {{#if url}}
-                           <h3 class="p-matrix__title"><a class="p-matrix__link" href="{{url}}">{{name}}</a></h3>
-                   {{else}}
-                           <h3 class="p-matrix__title">{{name}}</h3>
-                   {{/if}}
-                   {{#if api_docs}}
-                            <h2 class="p-matrix__title"><a class="p-matrix__link" href="{{api_docs}}">API</a></h2>
-                   {{/if}}
-                   {{#if api_endpoints}}
-                      <ul>
-                          {{#each api_endpoints}}
-                              <li>{{@key}}: {{this}}</li>
-                          {{/each}}
+      <div class="p-navigation__row">
+        <div class="p-navigation__banner">
+          <div class="p-navigation__tagged-logo">
+            <a class="p-navigation__link" href="#">
+              <div class="p-navigation__logo-tag">
+                <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
+              </div>
+              <span class="p-navigation__logo-title" id="nav">
+                {{title}}
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div class="p-strip--suru">
+      <div class="row">
+        <div class="col-12">
+          {{#if tagline}}
+            <h1>{{tagline}}</h1>
+          {{/if}}
+          {{#if description}}
+            <p>{{description}}</p>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+
+    <div class="p-strip">
+      <div class="row">
+        <div class="col12">
+          <h3>Applications</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-12">
+          {{#if apps}}
+            <ul class="p-matrix" id="apps">
+              {{#each apps}}
+                <li class="p-matrix__item">
+                  <div class="p-matrix__img">
+                    <span class="iconify icon md-48" data-icon="mdi-{{icon}}"></span>
+                  </div>
+                  <div class="p-matrix__content">
+                    <h3 class="p-matrix__title">{{name}}</h3>
+                    <div class="" style="display: flex; gap: 0;">
+                      <button class="p-tooltip--btm-center" id="ui-button" {{#unless url}}disabled{{/unless}}>
+                        {{#if url}}
+                          <a href="{{url}}" class="p-matrix__link" target="_blank" rel="noopener noreferrer">
+                            <span class="iconify" data-icon="mdi-web"></span>
+                            <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Visit UI</span>
+                          </a>
+                        {{else}}
+                          <span class="iconify" data-icon="mdi-web"></span>
+                          <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Visit UI</span>
+                        {{/if}}
+                      </button>
+
+                      {{#with this}}
+                        <button class="p-tooltip--btm-center" aria-controls="modal-{{@index}}" {{#unless (hasKeys api_endpoints)}}disabled{{/unless}}>
+                          <span class="iconify" data-icon="mdi-api"></span>
+                          <span class="p-tooltip__message" role="tooltip">View endpoints</span>
+                        </button>
+
+                        {{#getKeys api_endpoints}}
+                          <div class="p-modal" id="modal-{{@index}}" style="display: none;">
+                            <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title-{{@index}}" aria-describedby="modal-description-{{@index}}">
+                              <header class="p-modal__header">
+                                <h2 class="p-modal__title" id="modal-title-{{@index}}">API Endpoints for {{name}}</h2>
+                                <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal-{{@index}}">Close</button>
+                              </header>
+                              <div class="p-modal__content">
+                                <p id="modal-description-{{@index}}">
+                                  {{#each api_endpoints}}
+                                    <strong>{{@key}}</strong>: {{this}}
+                                  {{/each}}
+                                </p>
+                              </div>
+                            </section>
+                          </div>
+                        {{/getKeys}}
+                      {{/with}}
+
+                      <button class="p-tooltip--btm-center" id="docs-button" {{#unless api_docs}}disabled{{/unless}}>
+                        <a href="{{api_docs}}" class="p-matrix__link" target="_blank">
+                          <span class="iconify" data-icon="mdi-file-document"></span>
+                          <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Read docs</span>
+                        </a>
+                      </button>
+                    </div>
+                    {{#if description}}
+                      <p class="p-matrix__desc">{{description}}</p>
+                    {{/if}}
+                  </div>
+                </li>
+              {{/each}}
+            </ul>
+          {{else}}
+            <div class="p-notification--caution">
+              <div class="p-notification__content">
+                <h5 class="p-notification__title">No items to display</h5>
+                <p class="p-notification__message">No applications available for display yet. Add some by relating compatible charms to this one.</p>
+              </div>
+            </div>
+            <span></span>
+          {{/if}}
+        </div>
+      </div>
+
+      {{#if links}}
+        <div class="row">
+          <div class="col12">
+            <h3>Links</h3>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-12">
+            <ul class="p-matrix" id="links">
+              {{#each links}}
+                <li class="p-matrix__item">
+                  {{#if category}}
+                    <div class="p-matrix__img">
+                      <span class="iconify icon md-48" data-icon="mdi-bookmark"></span>
+                    </div>
+                    <div class="p-matrix__content">
+                      <h3 class="p-matrix__title">{{category}}</h3>
+                      <ul class="link-list">
+                        {{#each items}}
+                          <li>
+                            <a href="{{url}}" {{#if target}}target="{{target}}"{{/if}}>
+                              {{name}}
+                            </a>
+                          </li>
+                        {{/each}}
                       </ul>
+                    </div>
                   {{/if}}
-                   {{#if description}}
-                   <p class="p-matrix__desc">{{description}}</p>
-                   {{/if}}
-                 </div>
-    		  {{/if}}
-                 </li>
-               {{/each}}
-           </ul>
-           {{else}}
-           <div class="p-notification--caution">
-             <div class="p-notification__content">
-               <h5 class="p-notification__title">No items to display</h5>
-               <p class="p-notification__message">No applications available for display yet. Add some by relating compatible charms to this one.</p>
-             </div>
-           </div>
-           <span>
-
-           </span>
-           {{/if}}
-         </div>
-       </div>
-       {{#if links}}
-       <div class="row">
-         <div class="col12">
-           <h3>Links</h3>
-         </div>
-       </div>
-       <div class="row">
-         <div class="col-12">
-           <ul class="p-matrix" id="links">
-             {{! --- Links --- }}
-             {{#each links}}
-             <li class="p-matrix__item">
-               {{#if category}}
-               <div class="p-matrix__img">
-                 <span class="iconify icon md-48" data-icon="mdi-bookmark"></span>
-               </div>
-               <div class="p-matrix__content">
-                 <h3 class="p-matrix__title">{{category}}</h3>
-                 <ul class="link-list">
-                   {{#each items}}
-                   <li>
-                     <a href="{{url}}" {{#if target}}target="{{target}}"{{/if}}>
-                       {{name}}
-                     </a>
-                   </li>
-                   {{/each}}
-                 </ul>
-               </div>
-               {{/if}}
-             </li>
-             {{/each}}
-         </div>
-       </div>
-       {{/if}}
-     </div>
+                </li>
+              {{/each}}
+            </ul>
+          </div>
+        </div>
+      {{/if}}
+    </div>
   </script>
-
   <body id="root"></body>
   <script src="./ui.js" type="text/javascript"></script>
+  <script src="./modal.js" type="text/javascript"></script>
+  <script></script>
 </html>

--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -76,7 +76,6 @@
                             <h2 class="p-matrix__title"><a class="p-matrix__link" href="{{api_docs}}">API</a></h2>
                    {{/if}}
                    {{#if api_endpoints}}
-                   {{#if api_endpoints}}
                       <ul>
                           {{#each api_endpoints}}
                               <li>{{@key}}: {{this}}</li>

--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -1,132 +1,141 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="description" content="COS Dashboard" />
+    <meta
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      name="viewport"
+    />
+    <script>
+      // If there is no trailing slash at the end of the path in the url,
+      // add one. This ensures assets like ui.css are loaded properly
+      if (location.pathname.substr(-1) != "/") {
+        location.pathname = location.pathname + "/";
+        console.log("added slash");
+      }
+    </script>
+    <link rel="stylesheet" href="./vanilla-framework-3.7.1.min.css" />
+    <link rel="stylesheet" href="./ui.css" />
+    <script src="./handlebars.min.js"></script>
+    <script src="./iconify.min.js"></script>
+  </head>
+  <script type="text/handlebars-template" id="root-template">
+    <header id="navigation" class="p-navigation is-dark">
+       <div class="p-navigation__row">
+         <div class="p-navigation__banner">
+           <div class="p-navigation__tagged-logo">
+             <a class="p-navigation__link" href="#">
+               <div class="p-navigation__logo-tag">
+                 <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
+               </div>
+               <span class="p-navigation__logo-title" id="nav">
+                   {{title}}
+               </span>
+             </a>
+           </div>
+         </div>
+       </div>
+     </header>
+     <div class="p-strip--suru">
+       <div class="row">
+         <div class="col-12">
+           {{#if tagline}}
+             <h1>{{tagline}}</h1>
+           {{/if}}
+           {{#if description}}
+             <p>{{description}}</p>
+           {{/if}}
+         </div>
+       </div>
+     </div>
+     <div class="p-strip">
+       <div class="row">
+         <div class="col12">
+           <h3>Applications</h3>
+         </div>
+       </div>
+       <div class="row">
+         <div class="col-12">
+           {{#if apps}}
+           <ul class="p-matrix" id="apps">
+             {{! --- Apps --- }}
+             {{#each apps}}
+                 <li class="p-matrix__item">
+    		  {{#if name}}
+                 <div class="p-matrix__img">
+                   <span class="iconify icon md-48" data-icon="mdi-{{icon}}"></span>
+                 </div>
+                 <div class="p-matrix__content">
+                   {{#if url}}
+                           <h3 class="p-matrix__title"><a class="p-matrix__link" href="{{url}}">{{name}}</a></h3>
+                   {{else}}
+                           <h3 class="p-matrix__title">{{name}}</h3>
+                   {{/if}}
+                   {{#if api_docs}}
+                            <h2 class="p-matrix__title"><a class="p-matrix__link" href="{{api_docs}}">API</a></h2>
+                    {{else}}
+                           <h2 class="p-matrix__title">API</h2>
+                   {{/if}}
+                   {{#if description}}
+                   <p class="p-matrix__desc">{{description}}</p>
+                   {{/if}}
+                 </div>
 
-<head>
-  <meta charset="utf-8">
-  <meta name="description" content="COS Dashboard">
-  <meta content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    name="viewport" />
-  <script>
-    // If there is no trailing slash at the end of the path in the url,
-    // add one. This ensures assets like ui.css are loaded properly
-    if (location.pathname.substr(-1) != '/') {
-        location.pathname = location.pathname + '/';
-        console.log('added slash');
-    }
+    		  {{/if}}
+                 </li>
+               {{/each}}
+           </ul>
+           {{else}}
+           <div class="p-notification--caution">
+             <div class="p-notification__content">
+               <h5 class="p-notification__title">No items to display</h5>
+               <p class="p-notification__message">No applications available for display yet. Add some by relating compatible charms to this one.</p>
+             </div>
+           </div>
+           <span>
+
+           </span>
+           {{/if}}
+         </div>
+       </div>
+       {{#if links}}
+       <div class="row">
+         <div class="col12">
+           <h3>Links</h3>
+         </div>
+       </div>
+       <div class="row">
+         <div class="col-12">
+           <ul class="p-matrix" id="links">
+             {{! --- Links --- }}
+             {{#each links}}
+             <li class="p-matrix__item">
+               {{#if category}}
+               <div class="p-matrix__img">
+                 <span class="iconify icon md-48" data-icon="mdi-bookmark"></span>
+               </div>
+               <div class="p-matrix__content">
+                 <h3 class="p-matrix__title">{{category}}</h3>
+                 <ul class="link-list">
+                   {{#each items}}
+                   <li>
+                     <a href="{{url}}" {{#if target}}target="{{target}}"{{/if}}>
+                       {{name}}
+                     </a>
+                   </li>
+                   {{/each}}
+                 </ul>
+               </div>
+               {{/if}}
+             </li>
+             {{/each}}
+         </div>
+       </div>
+       {{/if}}
+     </div>
   </script>
-  <link rel="stylesheet" href="./vanilla-framework-3.7.1.min.css" />
-  <link rel="stylesheet" href="./ui.css" />
-  <script src="./handlebars.min.js"></script>
-  <script src="./iconify.min.js"></script>
 
-</head>
-<script type="text/handlebars-template" id="root-template">
- <header id="navigation" class="p-navigation is-dark">
-    <div class="p-navigation__row">
-      <div class="p-navigation__banner">
-        <div class="p-navigation__tagged-logo">
-          <a class="p-navigation__link" href="#">
-            <div class="p-navigation__logo-tag">
-              <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
-            </div>
-            <span class="p-navigation__logo-title" id="nav">
-                {{title}}
-            </span>
-          </a>
-        </div>
-      </div>
-    </div>
-  </header>
-  <div class="p-strip--suru">
-    <div class="row">
-      <div class="col-12">
-        {{#if tagline}}
-          <h1>{{tagline}}</h1>
-        {{/if}}
-        {{#if description}}
-          <p>{{description}}</p>
-        {{/if}}
-      </div>
-    </div>
-  </div>
-  <div class="p-strip">
-    <div class="row">
-      <div class="col12">
-        <h3>Applications</h3>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        {{#if apps}}
-        <ul class="p-matrix" id="apps">
-          {{! --- Apps --- }}
-          {{#each apps}}
-              <li class="p-matrix__item">
-			  {{#if name}}
-              <div class="p-matrix__img">
-                <span class="iconify icon md-48" data-icon="mdi-{{icon}}"></span>
-              </div>
-              <div class="p-matrix__content">
-                <h3 class="p-matrix__title"><a class="p-matrix__link" href="{{url}}">{{name}}</a></h3>
-                {{#if description}}
-                <p class="p-matrix__desc">{{description}}</p>
-                {{/if}}  
-              </div>
-			  {{/if}}
-              </li>
-            {{/each}}
-        </ul>
-        {{else}}
-        <div class="p-notification--caution">
-          <div class="p-notification__content">
-            <h5 class="p-notification__title">No items to display</h5>
-            <p class="p-notification__message">No applications available for display yet. Add some by relating compatible charms to this one.</p>
-          </div>
-        </div>
-        <span>
-          
-        </span>
-        {{/if}}
-      </div>
-    </div>
-    {{#if links}}
-    <div class="row">
-      <div class="col12">
-        <h3>Links</h3>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <ul class="p-matrix" id="links">
-          {{! --- Links --- }}
-          {{#each links}}
-          <li class="p-matrix__item">
-            {{#if category}}
-            <div class="p-matrix__img">
-              <span class="iconify icon md-48" data-icon="mdi-bookmark"></span>
-            </div>
-            <div class="p-matrix__content">
-              <h3 class="p-matrix__title">{{category}}</h3>
-              <ul class="link-list">
-                {{#each items}}
-                <li>
-                  <a href="{{url}}" {{#if target}}target="{{target}}"{{/if}}>
-                    {{name}}
-                  </a>
-                </li>
-                {{/each}}
-              </ul>
-            </div>
-            {{/if}}
-          </li>
-          {{/each}}
-      </div>
-    </div>
-    {{/if}}
-  </div>
-</script>
-
-<body id="root"></body>
-<script src="./ui.js" type="text/javascript"></script>
-
+  <body id="root"></body>
+  <script src="./ui.js" type="text/javascript"></script>
 </html>

--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -67,21 +67,14 @@
                   <div class="p-matrix__content">
                     <h3 class="p-matrix__title">{{name}}</h3>
                     <div class="" style="display: flex; gap: 0;">
-                      <button class="p-tooltip--btm-center" id="ui-button" {{#unless url}}disabled{{/unless}}>
-                        {{#if url}}
-                          <a href="{{url}}" class="p-matrix__link" target="_blank" rel="noopener noreferrer">
-                            <span class="iconify" data-icon="mdi-web"></span>
+        <button class="p-tooltip--btm-center openLinkBtn" id="ui-button" data-link="{{url}}" {{#unless url}}disabled{{/unless}}>
+                            <span class="iconify custom-icon" data-icon="mdi-web"></span>
                             <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Visit UI</span>
-                          </a>
-                        {{else}}
-                          <span class="iconify" data-icon="mdi-web"></span>
-                          <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Visit UI</span>
-                        {{/if}}
                       </button>
 
                       {{#with this}}
                         <button class="p-tooltip--btm-center" aria-controls="modal-{{@index}}" {{#unless (hasKeys api_endpoints)}}disabled{{/unless}}>
-                          <span class="iconify" data-icon="mdi-api"></span>
+                          <span class="iconify custom-icon" data-icon="mdi-api"></span>
                           <span class="p-tooltip__message" role="tooltip">View endpoints</span>
                         </button>
 
@@ -104,11 +97,9 @@
                         {{/getKeys}}
                       {{/with}}
 
-                      <button class="p-tooltip--btm-center" id="docs-button" {{#unless api_docs}}disabled{{/unless}}>
-                        <a href="{{api_docs}}" class="p-matrix__link" target="_blank">
-                          <span class="iconify" data-icon="mdi-file-document"></span>
+        <button class="p-tooltip--btm-center openLinkBtn" id="docs-button" data-link="{{api_docs}}" {{#unless api_docs}}disabled{{/unless}}>
+                          <span class="iconify custom-icon" data-icon="mdi-file-document"></span>
                           <span class="p-tooltip__message" role="tooltip" id="default-tooltip">Read docs</span>
-                        </a>
                       </button>
                     </div>
                     {{#if description}}

--- a/workload/ui/modal.js
+++ b/workload/ui/modal.js
@@ -77,7 +77,17 @@
       toggleModal(modal, false, false);
     });
   }
+  function handleOpenLinkButtons() {
+    document.addEventListener("click", function (event) {
+      var button = event.target.closest(".openLinkBtn");
+      if (!button) return;
+      var url = button.getAttribute("data-link");
 
+      if (url) {
+        window.open(url, "_blank");
+      }
+    });
+  }
   document.addEventListener("click", function (event) {
     var targetControls = event.target.getAttribute("aria-controls");
     if (targetControls) {
@@ -101,4 +111,5 @@
   Handlebars.registerHelper("hasKeys", function (obj) {
     return Object.keys(obj || {}).length > 0;
   });
+  handleOpenLinkButtons();
 })();

--- a/workload/ui/modal.js
+++ b/workload/ui/modal.js
@@ -1,0 +1,104 @@
+(function () {
+  var currentDialog = null;
+  var lastFocus = null;
+  var ignoreFocusChanges = false;
+  var focusAfterClose = null;
+
+  function trapFocus(event) {
+    if (ignoreFocusChanges) return;
+
+    if (currentDialog.contains(event.target)) {
+      lastFocus = event.target;
+    } else {
+      focusFirstDescendant(currentDialog);
+      if (lastFocus == document.activeElement) {
+        focusLastDescendant(currentDialog);
+      }
+      lastFocus = document.activeElement;
+    }
+  }
+
+  function attemptFocus(child) {
+    if (child.focus) {
+      ignoreFocusChanges = true;
+      child.focus();
+      ignoreFocusChanges = false;
+      return document.activeElement === child;
+    }
+    return false;
+  }
+
+  function focusFirstDescendant(element) {
+    for (var i = 0; i < element.childNodes.length; i++) {
+      var child = element.childNodes[i];
+      if (attemptFocus(child) || focusFirstDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function focusLastDescendant(element) {
+    for (var i = element.childNodes.length - 1; i >= 0; i--) {
+      var child = element.childNodes[i];
+      if (attemptFocus(child) || focusLastDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function toggleModal(modal, sourceEl, open) {
+    if (modal && modal.classList.contains("p-modal")) {
+      if (typeof open === "undefined") {
+        open = modal.style.display === "none";
+      }
+
+      if (open) {
+        currentDialog = modal;
+        modal.style.display = "flex";
+        focusFirstDescendant(modal);
+        focusAfterClose = sourceEl;
+        document.addEventListener("focus", trapFocus, true);
+      } else {
+        modal.style.display = "none";
+        if (focusAfterClose && focusAfterClose.focus) {
+          focusAfterClose.focus();
+        }
+        document.removeEventListener("focus", trapFocus, true);
+        currentDialog = null;
+      }
+    }
+  }
+
+  function closeModals() {
+    var modals = [].slice.call(document.querySelectorAll(".p-modal"));
+    modals.forEach(function (modal) {
+      toggleModal(modal, false, false);
+    });
+  }
+
+  document.addEventListener("click", function (event) {
+    var targetControls = event.target.getAttribute("aria-controls");
+    if (targetControls) {
+      toggleModal(document.getElementById(targetControls), event.target);
+    }
+  });
+
+  document.addEventListener("keydown", function (e) {
+    e = e || window.event;
+    if (e.code === "Escape" || e.keyCode === 27) {
+      closeModals();
+    }
+  });
+
+  Handlebars.registerHelper("getKeys", function (obj, options) {
+    return Object.keys(obj || {}).length > 0
+      ? options.fn(this)
+      : options.inverse(this);
+  });
+
+  Handlebars.registerHelper("hasKeys", function (obj) {
+    return Object.keys(obj || {}).length > 0;
+  });
+})();

--- a/workload/ui/ui.css
+++ b/workload/ui/ui.css
@@ -1,17 +1,21 @@
 .md-48 {
-    font-size: 36px;
-    color: #888;
-    border: 1px solid #d9d9d9;
-    padding: 8px;
-    border-radius: 100%;
+  font-size: 36px;
+  color: #888;
+  border: 1px solid #d9d9d9;
+  padding: 8px;
+  border-radius: 100%;
 }
 
 .p-matrix__item {
-    border: 0;
+  border: 0;
 }
 
 .link-list {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.custom-icon {
+  color: #008494;
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
- fixes https://github.com/canonical/mimir-coordinator-k8s-operator/issues/173
- fixes https://github.com/canonical/mimir-coordinator-k8s-operator/issues/158
- fixes #177


There are two main issues that this PR is attempting to solve.

1. Currently, an application like Mimir which does not have a UI, shows up on Catalogue with an `href` to its coordinator's leader IP. This is against what we want. For a UI-less app like Mimir, we want the app to show up on Catalogue, without an `href`.
2. In general, there are three categories a Catalogue item can fall under:
- Something like Mimir, has no UI, but it would be interesting to show endpoints it has that are relevant to the user. Its card on Catalogue should contain no `href`, but it should contain the API docs and some examples.
- Grafana has the UI, and most users would only be interested in the UI. Its card should only include an href, no need for its endpoints.
- Prometheus has both. Its card should include an href **AND** show its API docs and some relevant endpoints.

This PR includes changes to both the charm library and workload. The workload image should be updated to reflect this.

**Please note** that the PR only shows functionality for how Catalogue will roughly look when showing `api_endpoints`. We need to agree on the design.
## Solution
<!-- A summary of the solution addressing the above issue -->
To address issue 1 above, a change is made to the `catalogue` lib where we return an empty URL when there is no UI. For this change to take effect, this PR should go in, and in Mimir we have to fetch the new charm lib.

For the second issue, the PR introduces another change to the `catalogue` library. The `CatalogueItem` class now accepts an `api_docs` attribute which is a string and an `api_endpoints` attribute, which is a dictionary of string to string, where the key is a brief name (or description) for the endpoint (e.g. "Alerts") and the value is the actual endpoint. The hyperlink is removed from the name. Instead, there are three buttons under the name.
1. The first one is for the link to the UI. It's disabled when no URL is available (e.g. for Mimir). It uses the "web" icon.
2. The second one is a button that when clicked, opens a modal which lists the available endpoints. It's disabled when no endpoints are available.
3. The third button opens the API docs in a new tab. It is denoted by the document icon. Disabled when no docs available.

<img width="1936" height="957" alt="image" src="https://github.com/user-attachments/assets/ba1fddc2-9855-4315-a33a-1ca1a8bb5906" />

<img width="1936" height="957" alt="image" src="https://github.com/user-attachments/assets/534c41c7-db62-4464-a63f-c307dee6983f" />
<img width="1936" height="957" alt="image" src="https://github.com/user-attachments/assets/e64c91b5-7f09-41cb-ae36-536085d73013" />

<img width="1936" height="957" alt="image" src="https://github.com/user-attachments/assets/9e4f8483-baf0-47fc-9ea6-16871868da19" />

[Screencast from 2025-09-16 15-11-36.webm](https://github.com/user-attachments/assets/89acfc1e-fd4c-4dd7-9da4-17e49a3e7e80)



## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack the charm locally and deploy it `jd ./catalogue-k8s_ubuntu@24.04-amd64.charm catalogue2 --trust --resource catalogue-image=ghcr.io/canonical/catalogue-k8s-operator:latest`. 
5. Pack the Mimir coordinator locally and relate to Mimir worker and Catalogue. In [Mimir Coordinator src/charm](https://github.com/canonical/mimir-coordinator-k8s-operator/blob/715387274457d56cff1d7aac2fbbe3bc0ef2ef12/src/charm.py#L205), make sure you have made the following change at the linked line
```
@property
    def _catalogue_item(self) -> CatalogueItem:
        """A catalogue application entry for this Mimir instance."""
        return CatalogueItem(
            name="Mimir",
            icon="ruler",
            url="",
            description=(
                "Mimir provides horizontally scalable, highly available, "
                "multi-tenant, long-term storage for Prometheus. "
                "(no user interface available)"
            ),
            api_docs="https://grafana.com/docs/mimir/latest/references/http-api/",
            api_endpoints={"Alerts": f"{self.external_url}/api/v1/alerts"}
        )
```
6. Copy the `index.html` file and paste it in `/web/index.html` of the `catalogue` container for your Catalogue charm. 
7. When you go to the UI for catalogue, the two issues should be addressed:
- The name Mimir should not have an href.
- You should see the API docs and endpoints for Mimir:
<img width="2367" height="1138" alt="image" src="https://github.com/user-attachments/assets/ce2290e4-75ce-4cbe-a4cd-55a72fcd22aa" />


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->




## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack the charm locally and deploy it `jd ./catalogue-k8s_ubuntu@24.04-amd64.charm catalogue2 --trust --resource catalogue-image=ghcr.io/canonical/catalogue-k8s-operator:latest`. 
5. Pack the Mimir coordinator locally and relate to Mimir worker and Catalogue. In [Mimir Coordinator src/charm](https://github.com/canonical/mimir-coordinator-k8s-operator/blob/715387274457d56cff1d7aac2fbbe3bc0ef2ef12/src/charm.py#L205), make sure you have made the following change at the linked line
```
@property
    def _catalogue_item(self) -> CatalogueItem:
        """A catalogue application entry for this Mimir instance."""
        return CatalogueItem(
            name="Mimir",
            icon="ruler",
            url="",
            description=(
                "Mimir provides horizontally scalable, highly available, "
                "multi-tenant, long-term storage for Prometheus. "
                "(no user interface available)"
            ),
            api_docs="https://grafana.com/docs/mimir/latest/references/http-api/",
            api_endpoints={"Alerts": f"{self.external_url}/api/v1/alerts"}
        )
```
6. Copy the `index.html` file and paste it in `/web/index.html` of the `catalogue` container for your Catalogue charm. 
7. When you go to the Catalogue UI, it should look like the SSs above.


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
