### PR TITLE
chore: moved override_hostname test to scenario

### DIFF
--- a/charm/tests/unit/test_charm.py
+++ b/charm/tests/unit/test_charm.py
@@ -79,35 +79,6 @@ class TestCharm(unittest.TestCase):
             json.loads(data.read())["apps"],
         )
 
-    def test_override_hostname(self):
-        # Given the catalogue and a remote charm
-
-        rel_id = self.harness.add_relation(DEFAULT_RELATION_NAME, "rc")
-
-        # AND the override_hostname config option is set
-        override_hostname = "foo_bar"
-        self.harness.update_config({'override_hostname': override_hostname})
-
-        # When a remote relation is added
-        self.harness.add_relation_unit(rel_id, "rc/0")
-        self.harness.update_relation_data(
-            rel_id,
-            "rc",
-            {
-                "name": "remote-charm",
-                "url": "https://localhost/remote_charm",
-                "icon": "some-cool-icon",
-            },
-        )
-
-        data = self._container.pull("/web/config.json")
-
-        # THEN the base hostname of the URL for that app in config.json should show the override hostname
-        self.assertEqual(
-            f"https://{override_hostname}/remote_charm",
-            json.loads(data.read())["apps"][0]["url"],
-        )
-
 
     @patch.multiple(
         "charm.CatalogueCharm",

--- a/charm/tests/unit/test_override_hostname.py
+++ b/charm/tests/unit/test_override_hostname.py
@@ -1,0 +1,57 @@
+
+import json
+import logging
+
+from ops.testing import Container, Context, Relation, State
+
+from charm import CatalogueCharm
+
+logger = logging.getLogger(__name__)
+
+def test_override_hostname():
+    override_hostname = "foobar"
+    initial_url = "https://localhost/remote_charm"
+    overridden_url = f"https://{override_hostname}/remote_charm"
+
+    context = Context(CatalogueCharm)
+
+    container_name = "catalogue"
+    container = Container(name=container_name, can_connect=True)
+
+    remote_app_data = {
+                "name": "remote-charm",
+                "url": initial_url,
+                "icon": "some-cool-icon",
+                "description": "Remote charm description"
+            }
+    relation = Relation(remote_app_name="remote-charm", endpoint="catalogue", remote_app_data=remote_app_data)
+
+    state = State(
+        leader=True,
+        containers=[container],
+        relations=[relation],
+    )
+
+    state_out = context.run(context.on.config_changed(), state)
+
+    container_fs = state_out.get_container(container_name).get_filesystem(context)
+    cfg_file = container_fs / "web" / "config.json"
+
+    config = json.loads(cfg_file.read_text())
+    assert config['apps'][0]['url'] == initial_url
+
+    state = State(
+        leader=True,
+        containers=[container],
+        relations=[relation],
+        config={"override_hostname": override_hostname}
+    )
+
+    state_out = context.run(context.on.config_changed(), state)
+
+    container_fs = state_out.get_container(container_name).get_filesystem(context)
+    cfg_file = container_fs / "web" / "config.json"
+
+    config = json.loads(cfg_file.read_text())
+    assert config['apps'][0]['url'] == overridden_url
+


### PR DESCRIPTION
## Issue
Moves the recent override_hostname test (https://github.com/canonical/catalogue-k8s-operator/pull/183) from Harness to Scenario.


