### PR TITLE
fix: enhance endpoint label positioning

### DIFF
--- a/workload/ui/index.html
+++ b/workload/ui/index.html
@@ -86,11 +86,9 @@
                                 <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal-{{@index}}">Close</button>
                               </header>
                               <div class="p-modal__content">
-                                <p id="modal-description-{{@index}}">
-                                  {{#each api_endpoints}}
-                                    <strong>{{@key}}</strong>: {{this}}
-                                  {{/each}}
-                                </p>
+                                {{#each api_endpoints}}
+                                  <p><strong>{{@key}}</strong>: <span>{{this}}</span></p>
+                                {{/each}}
                               </div>
                             </section>
                           </div>


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
There is a minor issue with the API endpoints modal when there are multiple API endpoints available where the labels are slightly misplaced due to a misplaced <p> tag.
Before:
<img width="2525" height="1300" alt="Screenshot from 2025-09-17 15-50-59" src="https://github.com/user-attachments/assets/b473f319-80b4-4616-9a50-e19d251d0ce1" />

## Solution
<!-- A summary of the solution addressing the above issue -->
After:
<img width="2525" height="1300" alt="Screenshot from 2025-09-17 15-45-51" src="https://github.com/user-attachments/assets/340ec65b-4b32-428f-97d8-a48f00cc552b" />



## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
