### PR TITLE
add workflow for releasing rock on changes

### DIFF
--- a/.github/workflows/release-rock.yaml
+++ b/.github/workflows/release-rock.yaml
@@ -1,0 +1,36 @@
+name: Release Rock
+
+on:
+  push:
+    workflow_dispatch: {}
+    branches:
+      - main
+    paths:
+      - workload/**
+
+jobs:
+  release-rock:
+    name: Release Rock
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install rockcraft
+        run: sudo snap install rockcraft --classic
+
+      - name: Pack rock
+        run: cd workload && rockcraft pack
+
+      - name: Upload rock to ghcr.io
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          rock_file=$(ls workload/*.rock)
+          rockcraft.skopeo --insecure-policy copy \
+            oci-archive:"${rock_file}" \
+            docker://ghcr.io/canonical/catalogue-k8s-operator:latest \
+            --dest-creds "${GHCR_USER}:${GHCR_TOKEN}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the release process for the "Rock" artifact when changes are pushed to the `main` branch under the `workload/` directory. The workflow handles building and publishing the artifact to GitHub Container Registry. Also includes a dispatch for manual triggering.

resolves #213 