### PR TITLE
fix: TF release path is different for workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
     with:
       charm-path: charm
       default-track: dev
+      terraform-path: terraform
 
   release-rock:
     # rock-release-dev is actually releasing to ghcr in this case, as the `just release-ghcr` recipe is overridden


### PR DESCRIPTION
> [!IMPORTANT]
> We need to backport this into track/3.0 as well. 

## Issue
<!-- What issue is this PR trying to solve? -->
Related:
- https://github.com/canonical/observability/pull/471

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
